### PR TITLE
fix: tweak urls

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -94,6 +94,17 @@ impl<I: Iterator<Item = char>> Parser<I> {
         }
     }
 
+    /// consume whitespace token if there are any
+    fn optional_whitespace(&mut self) {
+        while let Some(TokenAt {
+            token: Token::Whitespace(),
+            ..
+        }) = self.tokens.peek()
+        {
+            self.tokens.next();
+        }
+    }
+
     pub fn into_stylesheet(mut self) -> Result<Stylesheet, ParsingError> {
         self.parse()
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -80,6 +80,7 @@ impl<I: Iterator<Item = char>> Parser<I> {
         T::parse(self)
     }
 
+    /// expect the next token to match a given token
     fn expect(&mut self, expected: Token) -> Result<(), ParsingError> {
         match self.tokens.next() {
             Some(token_at) => {

--- a/src/parser/url.rs
+++ b/src/parser/url.rs
@@ -12,7 +12,9 @@ impl Parsable for Url {
             Some(token_at) => match token_at.token {
                 Token::Url(url) => Ok(Url { url }),
                 Token::Function(name) if name == "url" => {
+                    parser.optional_whitespace();
                     let url: String = parser.parse()?;
+                    parser.optional_whitespace();
                     parser.expect(Token::CloseParenthesis())?;
                     Ok(Url { url })
                 }

--- a/src/parser/url.rs
+++ b/src/parser/url.rs
@@ -2,21 +2,19 @@ use super::*;
 use crate::tokenizer::*;
 
 #[derive(Debug, PartialEq, Eq)]
-struct Url {
-    url: String,
-}
+struct Url(String);
 
 impl Parsable for Url {
     fn parse<I: Iterator<Item = char>>(parser: &mut Parser<I>) -> Result<Self, ParsingError> {
         match parser.tokens.next() {
             Some(token_at) => match token_at.token {
-                Token::Url(url) => Ok(Url { url }),
+                Token::Url(url) => Ok(Url(url)),
                 Token::Function(name) if name == "url" => {
                     parser.optional_whitespace();
                     let url: String = parser.parse()?;
                     parser.optional_whitespace();
                     parser.expect(Token::CloseParenthesis())?;
-                    Ok(Url { url })
+                    Ok(Url(url))
                 }
                 _ => Err(ParsingError::wrong_token(token_at, "url")),
             },
@@ -34,12 +32,7 @@ mod tests {
     fn url() {
         let mut parser = Parser::new("url(example.com)".chars());
         let result = parser.parse::<Url>().unwrap();
-        assert_eq!(
-            result,
-            Url {
-                url: "example.com".to_owned()
-            }
-        );
+        assert_eq!(result, Url("example.com".to_owned()));
         assert!(parser.tokens.next().is_none());
     }
 
@@ -47,12 +40,7 @@ mod tests {
     fn function() {
         let mut parser = Parser::new("url('example.com')".chars());
         let result = parser.parse::<Url>().unwrap();
-        assert_eq!(
-            result,
-            Url {
-                url: "example.com".to_owned()
-            }
-        );
+        assert_eq!(result, Url("example.com".to_owned()));
         assert!(parser.tokens.next().is_none());
     }
 
@@ -60,12 +48,7 @@ mod tests {
     fn function_with_whitespace() {
         let mut parser = Parser::new("url(   'example.com'   )".chars());
         let result = parser.parse::<Url>().unwrap();
-        assert_eq!(
-            result,
-            Url {
-                url: "example.com".to_owned()
-            }
-        );
+        assert_eq!(result, Url("example.com".to_owned()));
         assert!(parser.tokens.next().is_none());
     }
 

--- a/src/parser/url.rs
+++ b/src/parser/url.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::tokenizer::*;
 
 #[derive(Debug, PartialEq, Eq)]
-struct Url(String);
+pub struct Url(String);
 
 impl Parsable for Url {
     fn parse<I: Iterator<Item = char>>(parser: &mut Parser<I>) -> Result<Self, ParsingError> {

--- a/src/parser/url.rs
+++ b/src/parser/url.rs
@@ -55,6 +55,19 @@ mod tests {
     }
 
     #[test]
+    fn function_with_whitespace() {
+        let mut parser = Parser::new("url(   'example.com'   )".chars());
+        let result = parser.parse::<Url>().unwrap();
+        assert_eq!(
+            result,
+            Url {
+                url: "example.com".to_owned()
+            }
+        );
+        assert!(parser.tokens.next().is_none());
+    }
+
+    #[test]
     fn not_url() {
         let mut parser = Parser::new("url".chars());
         assert!(parser.parse::<String>().is_err());


### PR DESCRIPTION
This PR fixes an issue where urls with quotes and whitespace where returning errors

This PR also changes Url to be a tuple struct because the property `url` was redundant