### PR TITLE
feat: parse media queries

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -94,6 +94,17 @@ impl<I: Iterator<Item = char>> Parser<I> {
         }
     }
 
+    /// consume whitespace token if there are any
+    fn optional_whitespace(&mut self) {
+        while let Some(TokenAt {
+            token: Token::Whitespace(),
+            ..
+        }) = self.tokens.peek()
+        {
+            self.tokens.next();
+        }
+    }
+
     pub fn into_stylesheet(mut self) -> Result<Stylesheet, ParsingError> {
         self.parse()
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -94,7 +94,7 @@ impl<I: Iterator<Item = char>> Parser<I> {
                 }
             }
 
-            None => Err(ParsingError::end_of_file("a string")),
+            None => Err(ParsingError::end_of_file(&expected.to_string())),
         }
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,6 +3,7 @@ use std::{fmt, str::FromStr};
 
 use crate::tokenizer::{Token, TokenAt, Tokenizer};
 
+mod from_identifier;
 mod media_query;
 mod string;
 mod url;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,6 +4,7 @@ use std::{fmt, str::FromStr};
 use crate::tokenizer::{Token, TokenAt, Tokenizer};
 
 mod from_identifier;
+mod length;
 mod media_query;
 mod string;
 mod url;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -116,6 +116,8 @@ pub trait Parsable: Sized {
     fn parse<I: Iterator<Item = char>>(parser: &mut Parser<I>) -> Result<Self, ParsingError>;
 }
 
+pub use from_identifier::FromIdentifier;
+
 pub struct Stylesheet {}
 
 impl Parsable for Stylesheet {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,6 +3,7 @@ use std::{fmt, str::FromStr};
 
 use crate::tokenizer::{Token, TokenAt, Tokenizer};
 
+mod media_query;
 mod string;
 mod url;
 

--- a/src/parser/from_identifier.rs
+++ b/src/parser/from_identifier.rs
@@ -1,0 +1,73 @@
+use super::*;
+
+// This trait signifies that a type can be parsed from an identifier using FromStr.
+pub trait FromIdentifier: FromStr {
+    // The expected identifier.
+    const EXPECTED: &'static str;
+}
+
+impl<T: FromIdentifier> Parsable for T {
+    fn parse<I: Iterator<Item = char>>(parser: &mut Parser<I>) -> Result<Self, ParsingError> {
+        match parser.tokens.next() {
+            Some(token_at) => match &token_at.token {
+                Token::Identifier(string) => match string.parse() {
+                    Ok(t) => Ok(t),
+                    Err(_) => Err(ParsingError::wrong_token(token_at, T::EXPECTED)),
+                },
+                _ => Err(ParsingError::wrong_token(token_at, T::EXPECTED)),
+            },
+
+            None => Err(ParsingError::end_of_file(T::EXPECTED)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// this struct is used to test the FromIdentifier trait
+    struct MockFromStr(String);
+
+    impl FromStr for MockFromStr {
+        type Err = ();
+
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            match s {
+                "error" => Err(()),
+                _ => Ok(MockFromStr(s.to_owned())),
+            }
+        }
+    }
+
+    // implement the FromIdentifier trait for MockFromStr
+    impl FromIdentifier for MockFromStr {
+        const EXPECTED: &'static str = "mock expected value";
+    }
+
+    #[test]
+    fn identifier() {
+        let mut parser = Parser::new("mock_input".chars());
+        let result = parser.parse::<MockFromStr>().unwrap();
+        assert_eq!(result.0, "mock_input");
+        assert!(parser.tokens.next().is_none());
+    }
+
+    #[test]
+    fn identifier_error() {
+        let mut parser = Parser::new("error".chars());
+        assert!(parser.parse::<MockFromStr>().is_err());
+    }
+
+    #[test]
+    fn not_identifier() {
+        let mut parser = Parser::new("3 is not an identifier".chars());
+        assert!(parser.parse::<MockFromStr>().is_err());
+    }
+
+    #[test]
+    fn nothing() {
+        let mut parser = Parser::new("".chars());
+        assert!(parser.parse::<MockFromStr>().is_err());
+    }
+}

--- a/src/parser/import.rs
+++ b/src/parser/import.rs
@@ -19,7 +19,17 @@ impl Parsable for Import {
 
                     parser.optional_whitespace();
 
-                    let media_queries: Vec<MediaQuery> = parser.parse()?;
+                    let media_queries: Vec<MediaQuery> = match parser.tokens.peek() {
+                        Some(token_at) => match token_at.token {
+                            Token::Identifier(_) | Token::OpenParenthesis() => parser.parse()?,
+                            Token::Semicolon() => Vec::new(),
+                            _ => Err(ParsingError::wrong_token(
+                                token_at.clone(),
+                                "a semicolon or media query",
+                            ))?,
+                        },
+                        None => Err(ParsingError::end_of_file("a semicolon or media query"))?,
+                    };
 
                     parser.optional_whitespace();
 
@@ -60,6 +70,55 @@ mod tests {
             Ok(Import {
                 url: Url("example.com".to_owned()),
                 media_queries: vec![]
+            }),
+            parser.parse()
+        );
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn string_url() {
+        let mut parser = Parser::new("@import 'example.com';".chars());
+        assert_eq!(
+            Ok(Import {
+                url: Url("example.com".to_owned()),
+                media_queries: vec![]
+            }),
+            parser.parse()
+        );
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn media_query() {
+        let mut parser = Parser::new("@import url(example.com) screen;".chars());
+        assert_eq!(
+            Ok(Import {
+                url: Url("example.com".to_owned()),
+                media_queries: vec![MediaQuery::MediaType(MediaType::Screen)]
+            }),
+            parser.parse()
+        );
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn complex_media_queries() {
+        let mut parser = Parser::new(
+            "@import url(example.com) screen and (orientation: landscape), (color);".chars(),
+        );
+        assert_eq!(
+            Ok(Import {
+                url: Url("example.com".to_owned()),
+                media_queries: vec![
+                    MediaQuery::And(
+                        Box::new(MediaQuery::MediaType(MediaType::Screen)),
+                        Box::new(MediaQuery::MediaFeature(MediaFeature::Orientation(
+                            Orientation::Landscape
+                        )))
+                    ),
+                    MediaQuery::MediaFeature(MediaFeature::Color)
+                ]
             }),
             parser.parse()
         );

--- a/src/parser/length.rs
+++ b/src/parser/length.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq)]
 pub enum Distance {}
 
 impl Parsable for Distance {

--- a/src/parser/length.rs
+++ b/src/parser/length.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+#[derive(Debug, PartialEq, Eq)]
 pub enum Distance {}
 
 impl Parsable for Distance {

--- a/src/parser/length.rs
+++ b/src/parser/length.rs
@@ -1,0 +1,9 @@
+use super::*;
+
+pub enum Distance {}
+
+impl Parsable for Distance {
+    fn parse<I: Iterator<Item = char>>(parser: &mut Parser<I>) -> Result<Self, ParsingError> {
+        todo!()
+    }
+}

--- a/src/parser/media_query.rs
+++ b/src/parser/media_query.rs
@@ -3,3 +3,14 @@ use crate::tokenizer::*;
 
 mod media_feature;
 mod media_type;
+
+use media_feature::*;
+use media_type::*;
+
+pub enum MediaQuery {
+    MediaType(MediaType),
+    MediaFeature(MediaFeature),
+    Not(Box<MediaQuery>),
+    And(Box<MediaQuery>, Box<MediaQuery>),
+    Or(Box<MediaQuery>, Box<MediaQuery>),
+}

--- a/src/parser/media_query.rs
+++ b/src/parser/media_query.rs
@@ -1,0 +1,4 @@
+use super::*;
+use crate::tokenizer::*;
+
+mod media_type;

--- a/src/parser/media_query.rs
+++ b/src/parser/media_query.rs
@@ -1,4 +1,5 @@
 use super::*;
 use crate::tokenizer::*;
 
+mod media_feature;
 mod media_type;

--- a/src/parser/media_query.rs
+++ b/src/parser/media_query.rs
@@ -5,8 +5,8 @@ mod media_feature;
 mod media_type;
 mod vec;
 
-use media_feature::*;
-use media_type::*;
+pub use media_feature::*;
+pub use media_type::*;
 pub use vec::*;
 
 #[derive(Debug, PartialEq)]

--- a/src/parser/media_query.rs
+++ b/src/parser/media_query.rs
@@ -7,6 +7,7 @@ mod media_type;
 use media_feature::*;
 use media_type::*;
 
+#[derive(Debug, PartialEq)]
 pub enum MediaQuery {
     MediaType(MediaType),
     MediaFeature(MediaFeature),

--- a/src/parser/media_query.rs
+++ b/src/parser/media_query.rs
@@ -42,10 +42,10 @@ impl Parsable for MediaQuery {
                         }
                         Some(_) => parser.parse(),
                         None => Err(ParsingError::end_of_file("media query")),
-                    };
+                    }?;
                     parser.optional_whitespace();
                     parser.expect(Token::CloseParenthesis())?;
-                    inner
+                    Ok(inner)
                 }
 
                 _ => Err(ParsingError::wrong_token(

--- a/src/parser/media_query.rs
+++ b/src/parser/media_query.rs
@@ -81,6 +81,12 @@ impl Parsable for MediaQuery {
     }
 }
 
+impl Parsable for Vec<MediaQuery> {
+    fn parse<I: Iterator<Item = char>>(parser: &mut Parser<I>) -> Result<Self, ParsingError> {
+        todo!()
+    }
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -222,6 +228,98 @@ mod tests {
                 )),
                 Box::new(MediaQuery::MediaType(MediaType::Print))
             )),
+            parser.parse()
+        );
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn list() {
+        let mut parser = Parser::new("screen, print".chars());
+        assert_eq!(
+            Ok(vec![
+                MediaQuery::MediaType(MediaType::Screen),
+                MediaQuery::MediaType(MediaType::Print)
+            ]),
+            parser.parse()
+        );
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn list_with_only_one() {
+        let mut parser = Parser::new("screen".chars());
+        assert_eq!(
+            Ok(vec![MediaQuery::MediaType(MediaType::Screen)]),
+            parser.parse()
+        );
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn empty_list() {
+        let mut parser = Parser::new("".chars());
+        assert!(parser.parse::<Vec<MediaQuery>>().is_err());
+    }
+
+    #[test]
+    fn list_with_no_whitespace() {
+        let mut parser = Parser::new("screen,print".chars());
+        assert_eq!(
+            Ok(vec![
+                MediaQuery::MediaType(MediaType::Screen),
+                MediaQuery::MediaType(MediaType::Print)
+            ]),
+            parser.parse()
+        );
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn list_with_extra_whitespace() {
+        let mut parser = Parser::new("screen   ,   print   ".chars());
+        assert_eq!(
+            Ok(vec![
+                MediaQuery::MediaType(MediaType::Screen),
+                MediaQuery::MediaType(MediaType::Print)
+            ]),
+            parser.parse()
+        );
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn trailing_comma() {
+        let mut parser = Parser::new("screen,print,".chars());
+        assert!(parser.parse::<Vec<MediaQuery>>().is_err());
+    }
+
+    #[test]
+    fn complex_list() {
+        let mut parser = Parser::new(
+            "(color) and screen, print and (orientation: landscape), not screen, (all or not all)"
+                .chars(),
+        );
+        assert_eq!(
+            Ok(vec![
+                MediaQuery::And(
+                    Box::new(MediaQuery::MediaFeature(MediaFeature::Color)),
+                    Box::new(MediaQuery::MediaType(MediaType::Screen)),
+                ),
+                MediaQuery::And(
+                    Box::new(MediaQuery::MediaType(MediaType::Print)),
+                    Box::new(MediaQuery::MediaFeature(MediaFeature::Orientation(
+                        Orientation::Landscape
+                    )))
+                ),
+                MediaQuery::Not(Box::new(MediaQuery::MediaType(MediaType::Screen))),
+                MediaQuery::Or(
+                    Box::new(MediaQuery::MediaType(MediaType::All)),
+                    Box::new(MediaQuery::Not(Box::new(MediaQuery::MediaType(
+                        MediaType::All
+                    ))))
+                )
+            ]),
             parser.parse()
         );
         assert_eq!(None, parser.tokens.next());

--- a/src/parser/media_query.rs
+++ b/src/parser/media_query.rs
@@ -15,3 +15,156 @@ pub enum MediaQuery {
     And(Box<MediaQuery>, Box<MediaQuery>),
     Or(Box<MediaQuery>, Box<MediaQuery>),
 }
+
+impl Parsable for MediaQuery {
+    fn parse<I: Iterator<Item = char>>(parser: &mut Parser<I>) -> Result<Self, ParsingError> {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn media_type() {
+        let mut parser = Parser::new("screen".chars());
+        assert_eq!(Ok(MediaQuery::MediaType(MediaType::Screen)), parser.parse());
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn media_feature() {
+        let mut parser = Parser::new("(color)".chars());
+        assert_eq!(
+            Ok(MediaQuery::MediaFeature(MediaFeature::Color)),
+            parser.parse()
+        );
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn media_feature_without_parentheses() {
+        let mut parser = Parser::new("color".chars());
+        assert!(parser.parse::<MediaQuery>().is_err());
+    }
+
+    #[test]
+    fn not() {
+        let mut parser = Parser::new("not screen".chars());
+        assert_eq!(
+            Ok(MediaQuery::Not(Box::new(MediaQuery::MediaType(
+                MediaType::Screen
+            )))),
+            parser.parse()
+        );
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn not_with_parentheses() {
+        let mut parser = Parser::new("not (screen)".chars());
+        assert_eq!(
+            Ok(MediaQuery::Not(Box::new(MediaQuery::MediaType(
+                MediaType::Screen
+            )))),
+            parser.parse()
+        );
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn and() {
+        let mut parser = Parser::new("screen and (color)".chars());
+        assert_eq!(
+            Ok(MediaQuery::And(
+                Box::new(MediaQuery::MediaType(MediaType::Screen)),
+                Box::new(MediaQuery::MediaFeature(MediaFeature::Color))
+            )),
+            parser.parse()
+        );
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn or() {
+        let mut parser = Parser::new("screen or (color)".chars());
+        assert_eq!(
+            Ok(MediaQuery::Or(
+                Box::new(MediaQuery::MediaType(MediaType::Screen)),
+                Box::new(MediaQuery::MediaFeature(MediaFeature::Color))
+            )),
+            parser.parse()
+        );
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn invalid_feature_with_and() {
+        let mut parser = Parser::new("(color and screen)".chars());
+        assert!(parser.parse::<MediaQuery>().is_err());
+    }
+
+    #[test]
+    fn and_or() {
+        // note that we do not have order of operations
+        let mut parser = Parser::new("screen and (color) or (orientation: landscape)".chars());
+        assert_eq!(
+            Ok(MediaQuery::And(
+                Box::new(MediaQuery::MediaType(MediaType::Screen)),
+                Box::new(MediaQuery::Or(
+                    Box::new(MediaQuery::MediaFeature(MediaFeature::Color)),
+                    Box::new(MediaQuery::MediaFeature(MediaFeature::Orientation(
+                        Orientation::Landscape
+                    )))
+                ))
+            )),
+            parser.parse()
+        );
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn parentheses() {
+        let mut parser = Parser::new("(screen)".chars());
+        assert_eq!(Ok(MediaQuery::MediaType(MediaType::Screen)), parser.parse());
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn parentheses_with_whitespace() {
+        let mut parser = Parser::new("( screen )".chars());
+        assert_eq!(Ok(MediaQuery::MediaType(MediaType::Screen)), parser.parse());
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn parentheses_with_whitespace_and_and() {
+        let mut parser = Parser::new("( screen and (color) )".chars());
+        assert_eq!(
+            Ok(MediaQuery::And(
+                Box::new(MediaQuery::MediaType(MediaType::Screen)),
+                Box::new(MediaQuery::MediaFeature(MediaFeature::Color))
+            )),
+            parser.parse()
+        );
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn lots_of_parentheses() {
+        let mut parser = Parser::new("((screen and (color)) or (((print))))".chars());
+        assert_eq!(
+            Ok(MediaQuery::Or(
+                Box::new(MediaQuery::And(
+                    Box::new(MediaQuery::MediaType(MediaType::Screen)),
+                    Box::new(MediaQuery::MediaFeature(MediaFeature::Color))
+                )),
+                Box::new(MediaQuery::MediaType(MediaType::Print))
+            )),
+            parser.parse()
+        );
+        assert_eq!(None, parser.tokens.next());
+    }
+}

--- a/src/parser/media_query.rs
+++ b/src/parser/media_query.rs
@@ -3,9 +3,11 @@ use crate::tokenizer::*;
 
 mod media_feature;
 mod media_type;
+mod vec;
 
 use media_feature::*;
 use media_type::*;
+pub use vec::*;
 
 #[derive(Debug, PartialEq)]
 pub enum MediaQuery {
@@ -78,12 +80,6 @@ impl Parsable for MediaQuery {
 
             _ => Ok(first),
         }
-    }
-}
-
-impl Parsable for Vec<MediaQuery> {
-    fn parse<I: Iterator<Item = char>>(parser: &mut Parser<I>) -> Result<Self, ParsingError> {
-        todo!()
     }
 }
 
@@ -228,98 +224,6 @@ mod tests {
                 )),
                 Box::new(MediaQuery::MediaType(MediaType::Print))
             )),
-            parser.parse()
-        );
-        assert_eq!(None, parser.tokens.next());
-    }
-
-    #[test]
-    fn list() {
-        let mut parser = Parser::new("screen, print".chars());
-        assert_eq!(
-            Ok(vec![
-                MediaQuery::MediaType(MediaType::Screen),
-                MediaQuery::MediaType(MediaType::Print)
-            ]),
-            parser.parse()
-        );
-        assert_eq!(None, parser.tokens.next());
-    }
-
-    #[test]
-    fn list_with_only_one() {
-        let mut parser = Parser::new("screen".chars());
-        assert_eq!(
-            Ok(vec![MediaQuery::MediaType(MediaType::Screen)]),
-            parser.parse()
-        );
-        assert_eq!(None, parser.tokens.next());
-    }
-
-    #[test]
-    fn empty_list() {
-        let mut parser = Parser::new("".chars());
-        assert!(parser.parse::<Vec<MediaQuery>>().is_err());
-    }
-
-    #[test]
-    fn list_with_no_whitespace() {
-        let mut parser = Parser::new("screen,print".chars());
-        assert_eq!(
-            Ok(vec![
-                MediaQuery::MediaType(MediaType::Screen),
-                MediaQuery::MediaType(MediaType::Print)
-            ]),
-            parser.parse()
-        );
-        assert_eq!(None, parser.tokens.next());
-    }
-
-    #[test]
-    fn list_with_extra_whitespace() {
-        let mut parser = Parser::new("screen   ,   print   ".chars());
-        assert_eq!(
-            Ok(vec![
-                MediaQuery::MediaType(MediaType::Screen),
-                MediaQuery::MediaType(MediaType::Print)
-            ]),
-            parser.parse()
-        );
-        assert_eq!(None, parser.tokens.next());
-    }
-
-    #[test]
-    fn trailing_comma() {
-        let mut parser = Parser::new("screen,print,".chars());
-        assert!(parser.parse::<Vec<MediaQuery>>().is_err());
-    }
-
-    #[test]
-    fn complex_list() {
-        let mut parser = Parser::new(
-            "(color) and screen, print and (orientation: landscape), not screen, (all or not all)"
-                .chars(),
-        );
-        assert_eq!(
-            Ok(vec![
-                MediaQuery::And(
-                    Box::new(MediaQuery::MediaFeature(MediaFeature::Color)),
-                    Box::new(MediaQuery::MediaType(MediaType::Screen)),
-                ),
-                MediaQuery::And(
-                    Box::new(MediaQuery::MediaType(MediaType::Print)),
-                    Box::new(MediaQuery::MediaFeature(MediaFeature::Orientation(
-                        Orientation::Landscape
-                    )))
-                ),
-                MediaQuery::Not(Box::new(MediaQuery::MediaType(MediaType::Screen))),
-                MediaQuery::Or(
-                    Box::new(MediaQuery::MediaType(MediaType::All)),
-                    Box::new(MediaQuery::Not(Box::new(MediaQuery::MediaType(
-                        MediaType::All
-                    ))))
-                )
-            ]),
             parser.parse()
         );
         assert_eq!(None, parser.tokens.next());

--- a/src/parser/media_query/media_feature.rs
+++ b/src/parser/media_query/media_feature.rs
@@ -12,7 +12,7 @@ use hover::*;
 use orientation::*;
 use pointer::*;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq)]
 pub enum MediaFeature {
     Color,
     Monochrome,

--- a/src/parser/media_query/media_feature.rs
+++ b/src/parser/media_query/media_feature.rs
@@ -7,10 +7,10 @@ mod hover;
 mod orientation;
 mod pointer;
 
-use color_scheme::*;
-use hover::*;
-use orientation::*;
-use pointer::*;
+pub use color_scheme::ColorScheme;
+pub use hover::Hover;
+pub use orientation::Orientation;
+pub use pointer::Pointer;
 
 #[derive(Debug, PartialEq)]
 pub enum MediaFeature {

--- a/src/parser/media_query/media_feature.rs
+++ b/src/parser/media_query/media_feature.rs
@@ -1,0 +1,30 @@
+use crate::parser::length::Distance;
+
+use super::*;
+
+mod color_scheme;
+mod hover;
+mod orientation;
+mod pointer;
+
+use color_scheme::*;
+use hover::*;
+use orientation::*;
+use pointer::*;
+
+pub enum MediaFeature {
+    Color,
+    MonoChrome,
+    MinWidth(Distance),
+    Width(Distance),
+    MaxWidth(Distance),
+    MinHeight(Distance),
+    Height(Distance),
+    MaxHeight(Distance),
+    Orientation(Orientation),
+    Hover(Hover),
+    AnyHover(Hover),
+    Pointer(Pointer),
+    AnyPointer(Pointer),
+    PrefersColorScheme(ColorScheme),
+}

--- a/src/parser/media_query/media_feature.rs
+++ b/src/parser/media_query/media_feature.rs
@@ -12,9 +12,10 @@ use hover::*;
 use orientation::*;
 use pointer::*;
 
+#[derive(Debug, PartialEq, Eq)]
 pub enum MediaFeature {
     Color,
-    MonoChrome,
+    Monochrome,
     MinWidth(Distance),
     Width(Distance),
     MaxWidth(Distance),
@@ -27,4 +28,172 @@ pub enum MediaFeature {
     Pointer(Pointer),
     AnyPointer(Pointer),
     PrefersColorScheme(ColorScheme),
+}
+
+impl<I: Iterator<Item = char>> Parser<I> {
+    fn consume_colon_separator(&mut self) -> Result<(), ParsingError> {
+        self.optional_whitespace();
+        self.expect(Token::Colon())?;
+        self.optional_whitespace();
+        Ok(())
+    }
+}
+
+impl Parsable for MediaFeature {
+    fn parse<I: Iterator<Item = char>>(parser: &mut Parser<I>) -> Result<Self, ParsingError> {
+        match parser.tokens.next() {
+            Some(token_at) => match &token_at.token {
+                Token::Identifier(string) => match string.as_str() {
+                    "color" => Ok(MediaFeature::Color),
+                    "monochrome" => Ok(MediaFeature::Monochrome),
+                    "min-width" => {
+                        parser.consume_colon_separator()?;
+                        let distance: Distance = parser.parse()?;
+                        Ok(MediaFeature::MinWidth(distance))
+                    }
+                    "width" => {
+                        parser.consume_colon_separator()?;
+                        let distance: Distance = parser.parse()?;
+                        Ok(MediaFeature::Width(distance))
+                    }
+                    "max-width" => {
+                        parser.consume_colon_separator()?;
+                        let distance: Distance = parser.parse()?;
+                        Ok(MediaFeature::MaxWidth(distance))
+                    }
+                    "min-height" => {
+                        parser.consume_colon_separator()?;
+                        let distance: Distance = parser.parse()?;
+                        Ok(MediaFeature::MinHeight(distance))
+                    }
+                    "height" => {
+                        parser.consume_colon_separator()?;
+                        let distance: Distance = parser.parse()?;
+                        Ok(MediaFeature::Height(distance))
+                    }
+                    "max-height" => {
+                        parser.consume_colon_separator()?;
+                        let distance: Distance = parser.parse()?;
+                        Ok(MediaFeature::MaxHeight(distance))
+                    }
+                    "orientation" => {
+                        parser.consume_colon_separator()?;
+                        let orientation: Orientation = parser.parse()?;
+                        Ok(MediaFeature::Orientation(orientation))
+                    }
+                    "hover" => {
+                        parser.consume_colon_separator()?;
+                        let hover: Hover = parser.parse()?;
+                        Ok(MediaFeature::Hover(hover))
+                    }
+                    "any-hover" => {
+                        parser.consume_colon_separator()?;
+                        let hover: Hover = parser.parse()?;
+                        Ok(MediaFeature::AnyHover(hover))
+                    }
+                    "pointer" => {
+                        parser.consume_colon_separator()?;
+                        let pointer: Pointer = parser.parse()?;
+                        Ok(MediaFeature::Pointer(pointer))
+                    }
+                    "any-pointer" => {
+                        parser.consume_colon_separator()?;
+                        let pointer: Pointer = parser.parse()?;
+                        Ok(MediaFeature::AnyPointer(pointer))
+                    }
+                    "prefers-color-scheme" => {
+                        parser.consume_colon_separator()?;
+                        let color_scheme: ColorScheme = parser.parse()?;
+                        Ok(MediaFeature::PrefersColorScheme(color_scheme))
+                    }
+                    _ => Err(ParsingError::wrong_token(token_at, "a media feature")),
+                },
+
+                _ => Err(ParsingError::wrong_token(token_at, "a media feature")),
+            },
+
+            None => Err(ParsingError::end_of_file("identifier")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn color() {
+        let mut parser = Parser::new("color".chars());
+        assert_eq!(Ok(MediaFeature::Color), parser.parse());
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn monochrome() {
+        let mut parser = Parser::new("monochrome".chars());
+        assert_eq!(Ok(MediaFeature::Monochrome), parser.parse());
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn orientation() {
+        let mut parser = Parser::new("orientation: portrait".chars());
+        assert_eq!(
+            Ok(MediaFeature::Orientation(Orientation::Portrait)),
+            parser.parse()
+        );
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn hover() {
+        let mut parser = Parser::new("hover: hover".chars());
+        assert_eq!(Ok(MediaFeature::Hover(Hover::Hover)), parser.parse());
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn any_hover() {
+        let mut parser = Parser::new("any-hover: hover".chars());
+        assert_eq!(Ok(MediaFeature::AnyHover(Hover::Hover)), parser.parse());
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn pointer() {
+        let mut parser = Parser::new("pointer: fine".chars());
+        assert_eq!(Ok(MediaFeature::Pointer(Pointer::Fine)), parser.parse());
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn any_pointer() {
+        let mut parser = Parser::new("any-pointer: fine".chars());
+        assert_eq!(Ok(MediaFeature::AnyPointer(Pointer::Fine)), parser.parse());
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn prefers_color_scheme() {
+        let mut parser = Parser::new("prefers-color-scheme: dark".chars());
+        assert_eq!(
+            Ok(MediaFeature::PrefersColorScheme(ColorScheme::Dark)),
+            parser.parse()
+        );
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn no_whitespace() {
+        let mut parser = Parser::new("hover:hover".chars());
+        assert_eq!(Ok(MediaFeature::Hover(Hover::Hover)), parser.parse());
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn extra_whitespace() {
+        let mut parser = Parser::new("hover   :   hover".chars());
+        assert_eq!(Ok(MediaFeature::Hover(Hover::Hover)), parser.parse());
+        assert_eq!(None, parser.tokens.next());
+    }
 }

--- a/src/parser/media_query/media_feature/color_scheme.rs
+++ b/src/parser/media_query/media_feature/color_scheme.rs
@@ -1,0 +1,22 @@
+use super::*;
+
+pub enum ColorScheme {
+    Light,
+    Dark,
+}
+
+impl FromStr for ColorScheme {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "light" => Ok(ColorScheme::Light),
+            "dark" => Ok(ColorScheme::Dark),
+            _ => Err(()),
+        }
+    }
+}
+
+impl FromIdentifier for ColorScheme {
+    const EXPECTED: &'static str = "light or dark";
+}

--- a/src/parser/media_query/media_feature/color_scheme.rs
+++ b/src/parser/media_query/media_feature/color_scheme.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+#[derive(Debug, PartialEq, Eq)]
 pub enum ColorScheme {
     Light,
     Dark,
@@ -19,4 +20,24 @@ impl FromStr for ColorScheme {
 
 impl FromIdentifier for ColorScheme {
     const EXPECTED: &'static str = "light or dark";
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn light() {
+        assert_eq!(Ok(ColorScheme::Light), "light".parse::<ColorScheme>());
+    }
+
+    #[test]
+    fn dark() {
+        assert_eq!(Ok(ColorScheme::Dark), "dark".parse::<ColorScheme>());
+    }
+
+    #[test]
+    fn not_color_scheme() {
+        assert!("not a color scheme".parse::<ColorScheme>().is_err());
+    }
 }

--- a/src/parser/media_query/media_feature/hover.rs
+++ b/src/parser/media_query/media_feature/hover.rs
@@ -1,0 +1,22 @@
+use super::*;
+
+pub enum Hover {
+    Hover,
+    None,
+}
+
+impl FromStr for Hover {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "hover" => Ok(Hover::Hover),
+            "none" => Ok(Hover::None),
+            _ => Err(()),
+        }
+    }
+}
+
+impl FromIdentifier for Hover {
+    const EXPECTED: &'static str = "hover or none";
+}

--- a/src/parser/media_query/media_feature/hover.rs
+++ b/src/parser/media_query/media_feature/hover.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+#[derive(Debug, PartialEq, Eq)]
 pub enum Hover {
     Hover,
     None,
@@ -19,4 +20,24 @@ impl FromStr for Hover {
 
 impl FromIdentifier for Hover {
     const EXPECTED: &'static str = "hover or none";
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hover() {
+        assert_eq!(Ok(Hover::Hover), "hover".parse());
+    }
+
+    #[test]
+    fn none() {
+        assert_eq!(Ok(Hover::None), "none".parse());
+    }
+
+    #[test]
+    fn not_hover() {
+        assert!("not hover".parse::<Hover>().is_err());
+    }
 }

--- a/src/parser/media_query/media_feature/orientation.rs
+++ b/src/parser/media_query/media_feature/orientation.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+#[derive(Debug, PartialEq, Eq)]
 pub enum Orientation {
     Portrait,
     Landscape,
@@ -19,4 +20,24 @@ impl FromStr for Orientation {
 
 impl FromIdentifier for Orientation {
     const EXPECTED: &'static str = "portrait or landscape";
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn portrait() {
+        assert_eq!(Ok(Orientation::Portrait), "portrait".parse());
+    }
+
+    #[test]
+    fn landscape() {
+        assert_eq!(Ok(Orientation::Landscape), "landscape".parse());
+    }
+
+    #[test]
+    fn not_orientation() {
+        assert!("not orientation".parse::<Orientation>().is_err());
+    }
 }

--- a/src/parser/media_query/media_feature/orientation.rs
+++ b/src/parser/media_query/media_feature/orientation.rs
@@ -1,0 +1,22 @@
+use super::*;
+
+pub enum Orientation {
+    Portrait,
+    Landscape,
+}
+
+impl FromStr for Orientation {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "portrait" => Ok(Orientation::Portrait),
+            "landscape" => Ok(Orientation::Landscape),
+            _ => Err(()),
+        }
+    }
+}
+
+impl FromIdentifier for Orientation {
+    const EXPECTED: &'static str = "portrait or landscape";
+}

--- a/src/parser/media_query/media_feature/pointer.rs
+++ b/src/parser/media_query/media_feature/pointer.rs
@@ -1,0 +1,24 @@
+use super::*;
+
+pub enum Pointer {
+    Fine,
+    Coarse,
+    None,
+}
+
+impl FromStr for Pointer {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "fine" => Ok(Pointer::Fine),
+            "coarse" => Ok(Pointer::Coarse),
+            "none" => Ok(Pointer::None),
+            _ => Err(()),
+        }
+    }
+}
+
+impl FromIdentifier for Pointer {
+    const EXPECTED: &'static str = "fine, coarse, or none";
+}

--- a/src/parser/media_query/media_feature/pointer.rs
+++ b/src/parser/media_query/media_feature/pointer.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+#[derive(Debug, PartialEq, Eq)]
 pub enum Pointer {
     Fine,
     Coarse,
@@ -21,4 +22,29 @@ impl FromStr for Pointer {
 
 impl FromIdentifier for Pointer {
     const EXPECTED: &'static str = "fine, coarse, or none";
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fine() {
+        assert_eq!(Ok(Pointer::Fine), "fine".parse());
+    }
+
+    #[test]
+    fn coarse() {
+        assert_eq!(Ok(Pointer::Coarse), "coarse".parse());
+    }
+
+    #[test]
+    fn none() {
+        assert_eq!(Ok(Pointer::None), "none".parse());
+    }
+
+    #[test]
+    fn not_pointer() {
+        assert!("not pointer".parse::<Pointer>().is_err());
+    }
 }

--- a/src/parser/media_query/media_type.rs
+++ b/src/parser/media_query/media_type.rs
@@ -1,0 +1,78 @@
+use super::*;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum MediaType {
+    All,
+    Print,
+    Screen,
+}
+
+impl FromStr for MediaType {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "all" => Ok(MediaType::All),
+            "print" => Ok(MediaType::Print),
+            "screen" => Ok(MediaType::Screen),
+            _ => Err(()),
+        }
+    }
+}
+
+impl Parsable for MediaType {
+    fn parse<I: Iterator<Item = char>>(parser: &mut Parser<I>) -> Result<Self, ParsingError> {
+        match parser.tokens.next() {
+            Some(token_at) => match &token_at.token {
+                Token::Identifier(string) => match string.parse() {
+                    Ok(media_type) => Ok(media_type),
+                    Err(_) => Err(ParsingError::wrong_token(token_at, "all, print, or screen")),
+                },
+                _ => Err(ParsingError::wrong_token(token_at, "all, print, or screen")),
+            },
+
+            None => Err(ParsingError::end_of_file("all, print, or screen")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all() {
+        let mut parser = Parser::new("all".chars());
+        let result = parser.parse::<MediaType>().unwrap();
+        assert_eq!(result, MediaType::All);
+        assert!(parser.tokens.next().is_none());
+    }
+
+    #[test]
+    fn print() {
+        let mut parser = Parser::new("print".chars());
+        let result = parser.parse::<MediaType>().unwrap();
+        assert_eq!(result, MediaType::Print);
+        assert!(parser.tokens.next().is_none());
+    }
+
+    #[test]
+    fn screen() {
+        let mut parser = Parser::new("screen".chars());
+        let result = parser.parse::<MediaType>().unwrap();
+        assert_eq!(result, MediaType::Screen);
+        assert!(parser.tokens.next().is_none());
+    }
+
+    #[test]
+    fn not_media_type() {
+        let mut parser = Parser::new("not a media type".chars());
+        assert!(parser.parse::<MediaType>().is_err());
+    }
+
+    #[test]
+    fn nothing() {
+        let mut parser = Parser::new("".chars());
+        assert!(parser.parse::<MediaType>().is_err());
+    }
+}

--- a/src/parser/media_query/media_type.rs
+++ b/src/parser/media_query/media_type.rs
@@ -20,20 +20,8 @@ impl FromStr for MediaType {
     }
 }
 
-impl Parsable for MediaType {
-    fn parse<I: Iterator<Item = char>>(parser: &mut Parser<I>) -> Result<Self, ParsingError> {
-        match parser.tokens.next() {
-            Some(token_at) => match &token_at.token {
-                Token::Identifier(string) => match string.parse() {
-                    Ok(media_type) => Ok(media_type),
-                    Err(_) => Err(ParsingError::wrong_token(token_at, "all, print, or screen")),
-                },
-                _ => Err(ParsingError::wrong_token(token_at, "all, print, or screen")),
-            },
-
-            None => Err(ParsingError::end_of_file("all, print, or screen")),
-        }
-    }
+impl FromIdentifier for MediaType {
+    const EXPECTED: &'static str = "all, print, or screen";
 }
 
 #[cfg(test)]

--- a/src/parser/media_query/vec.rs
+++ b/src/parser/media_query/vec.rs
@@ -1,0 +1,104 @@
+use super::*;
+
+impl Parsable for Vec<MediaQuery> {
+    fn parse<I: Iterator<Item = char>>(parser: &mut Parser<I>) -> Result<Self, ParsingError> {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn one() {
+        let mut parser = Parser::new("screen".chars());
+        assert_eq!(
+            Ok(vec![MediaQuery::MediaType(MediaType::Screen)]),
+            parser.parse()
+        );
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn tow() {
+        let mut parser = Parser::new("screen, print".chars());
+        assert_eq!(
+            Ok(vec![
+                MediaQuery::MediaType(MediaType::Screen),
+                MediaQuery::MediaType(MediaType::Print)
+            ]),
+            parser.parse()
+        );
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn empty() {
+        let mut parser = Parser::new("".chars());
+        assert!(parser.parse::<Vec<MediaQuery>>().is_err());
+    }
+
+    #[test]
+    fn no_whitespace() {
+        let mut parser = Parser::new("screen,print".chars());
+        assert_eq!(
+            Ok(vec![
+                MediaQuery::MediaType(MediaType::Screen),
+                MediaQuery::MediaType(MediaType::Print)
+            ]),
+            parser.parse()
+        );
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn extra_whitespace() {
+        let mut parser = Parser::new("screen   ,   print   ".chars());
+        assert_eq!(
+            Ok(vec![
+                MediaQuery::MediaType(MediaType::Screen),
+                MediaQuery::MediaType(MediaType::Print)
+            ]),
+            parser.parse()
+        );
+        assert_eq!(None, parser.tokens.next());
+    }
+
+    #[test]
+    fn trailing_comma() {
+        let mut parser = Parser::new("screen,print,".chars());
+        assert!(parser.parse::<Vec<MediaQuery>>().is_err());
+    }
+
+    #[test]
+    fn complex() {
+        let mut parser = Parser::new(
+            "(color) and screen, print and (orientation: landscape), not screen, (all or not all)"
+                .chars(),
+        );
+        assert_eq!(
+            Ok(vec![
+                MediaQuery::And(
+                    Box::new(MediaQuery::MediaFeature(MediaFeature::Color)),
+                    Box::new(MediaQuery::MediaType(MediaType::Screen)),
+                ),
+                MediaQuery::And(
+                    Box::new(MediaQuery::MediaType(MediaType::Print)),
+                    Box::new(MediaQuery::MediaFeature(MediaFeature::Orientation(
+                        Orientation::Landscape
+                    )))
+                ),
+                MediaQuery::Not(Box::new(MediaQuery::MediaType(MediaType::Screen))),
+                MediaQuery::Or(
+                    Box::new(MediaQuery::MediaType(MediaType::All)),
+                    Box::new(MediaQuery::Not(Box::new(MediaQuery::MediaType(
+                        MediaType::All
+                    ))))
+                )
+            ]),
+            parser.parse()
+        );
+        assert_eq!(None, parser.tokens.next());
+    }
+}

--- a/src/parser/media_query/vec.rs
+++ b/src/parser/media_query/vec.rs
@@ -2,7 +2,24 @@ use super::*;
 
 impl Parsable for Vec<MediaQuery> {
     fn parse<I: Iterator<Item = char>>(parser: &mut Parser<I>) -> Result<Self, ParsingError> {
-        todo!()
+        let mut media_queries = Vec::new();
+        loop {
+            media_queries.push(parser.parse()?);
+            parser.optional_whitespace();
+
+            match parser.tokens.peek() {
+                Some(TokenAt {
+                    token: Token::Comma(),
+                    ..
+                }) => {
+                    parser.tokens.next();
+                    parser.optional_whitespace();
+                    continue;
+                }
+                _ => break,
+            }
+        }
+        Ok(media_queries)
     }
 }
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -11,7 +11,7 @@ use line_counter::LineCounter;
 /// All the types of tokens found in CSS
 ///
 /// adapted from https://www.w3.org/TR/css-syntax-3/#tokenization
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Token {
     BadComment(),
     Identifier(String),
@@ -38,7 +38,7 @@ pub enum Token {
     CloseCurlyBracket(),
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum HashType {
     Id,
     Unrestricted,
@@ -75,7 +75,7 @@ impl fmt::Display for Token {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct TokenAt {
     pub line: usize,
     pub column: usize,

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -75,7 +75,7 @@ impl fmt::Display for Token {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct TokenAt {
     pub line: usize,
     pub column: usize,


### PR DESCRIPTION
not that this does not import media rules only media queries

the clippy warnings are caused by length and ruleset not being implemented yet