### PR TITLE
feat: use `unimplemented` for escape sequence errors

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -112,7 +112,7 @@ impl<I: Iterator<Item = char>> Tokenizer<I> {
         match self.chars.peek() {
             Some((_, _, character)) => match character {
                 'a'..='z' | 'A'..='Z' | '_' => true,
-                '\\' => todo!("add support for escapes"),
+                '\\' => unimplemented!("escape sequences"),
                 _ => false,
             },
             None => false,
@@ -130,7 +130,7 @@ impl<I: Iterator<Item = char>> Tokenizer<I> {
                     identifier.push(character);
                 }
                 '\\' => {
-                    todo!("add support for escapes");
+                    unimplemented!("escape sequences");
                 }
                 _ => break,
             }
@@ -182,7 +182,7 @@ impl<I: Iterator<Item = char>> Tokenizer<I> {
                 ' ' | '\t' | '\r' | '\n' => break,
                 '"' | '\'' | '(' | '\0' | '\x08' | '\x0B' | '\x0E'..='\x1F' | '\x7F' => break,
                 '\\' => {
-                    todo!("add support for escapes");
+                    unimplemented!("escape sequences");
                 }
                 _ => {
                     self.chars.next();
@@ -345,7 +345,7 @@ impl<I: Iterator<Item = char>> Iterator for Tokenizer<I> {
                     '0'..='9' | '-' => {
                         Token::Hash(self.consume_identifier_sequence(), HashType::Unrestricted)
                     }
-                    '\\' => todo!("add support for escapes"),
+                    '\\' => unimplemented!("escape sequences"),
                     _ => Token::Delimiter('#'),
                 },
                 None => Token::Delimiter('#'),
@@ -388,7 +388,7 @@ impl<I: Iterator<Item = char>> Iterator for Tokenizer<I> {
                 }
             }
 
-            '\\' => todo!("add support for escapes"),
+            '\\' => unimplemented!("escape sequences"),
             ':' => Token::Colon(),
             ';' => Token::Semicolon(),
             ',' => Token::Comma(),


### PR DESCRIPTION
Use `unimplemented!` instead of `todo!` for error messages regarding escape sequence support. Due to time constraints, we do not intend to support escape sequences.